### PR TITLE
Use defer_as instead of to_ for Deferrables.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,7 +32,7 @@ For operations that require IO, em-mongo always returns an EventMachine deferrab
       #most cursor methods return an EM::Mongo::RequestResponse,
       #which is an EventMachine::Deferrable
 
-      resp = cursor.to_a 
+      resp = cursor.defer_as_a
 
       #when em-mongo IO methods succeed, they 
       #will always call back with the return
@@ -85,11 +85,11 @@ em-mongo will present errors in two different ways. First, em-mongo will raise e
 
 Errors returned by the database, or errors communicating with the database, will be delivered via standard EM::Deferrable errbacks. While it is tempting to subscribe just to a callback
 
-  my_colletion.find.to_a.callback {|docs| ... }
+  my_colletion.find.defer_as_a.callback {|docs| ... }
 
 in the case of an error you will never receive a response. If you are waiting for a response before your program continues, you will be waiting a very long time. A better approach would be to store the deferrable into a variable and subscribe to its callback and errback
 
-  resp = my_collection.find.to_a
+  resp = my_collection.find.defer_as_a
   resp.callback { |docs| ... }
   resp.errback { |err| raise *err }
 
@@ -136,13 +136,13 @@ to this
 
   my_collection.first().callback { |doc| p doc }
 
-EM::Mongo::Collection#find now returns a cursor, not an array, to maintain compatibility with the mongo-ruby-driver. This provides a great deal more flexibility, but requires you to select a specific cursor method to actually fetch data from the server, such as #to_a or #next
+EM::Mongo::Collection#find now returns a cursor, not an array, to maintain compatibility with the mongo-ruby-driver. This provides a great deal more flexibility, but requires you to select a specific cursor method to actually fetch data from the server, such as #defer_as_a or #next
 
   my_collection.find() { |docs| ... }
 
 becomes
 
-  my_collection.find.to_a.callback { |docs| ... }
+  my_collection.find.defer_as_a.callback { |docs| ... }
 
 If for some reason you aren't ready to upgrade your project but you want to be able to use the newer gem, you can require a compatibility file that will revert the new API to the API found in 0.3.6
 

--- a/lib/em-mongo/cursor.rb
+++ b/lib/em-mongo/cursor.rb
@@ -299,7 +299,7 @@ module EM::Mongo
     # efficient to retrieve documents as you need them by iterating over the cursor.
     #
     # @return [EM::Mongo::RequestResponse] Calls back with an array of documents.
-    def to_a
+    def defer_as_a
       response = RequestResponse.new
       items = []
       self.each do |doc,err|
@@ -313,6 +313,9 @@ module EM::Mongo
       end
       response
     end
+
+    # XXX to_a is confusing but we will leave it for now
+    alias to_a defer_as_a
 
     # Get the explain plan for this cursor.
     #

--- a/lib/em-mongo/database.rb
+++ b/lib/em-mongo/database.rb
@@ -52,7 +52,7 @@ module EM::Mongo
     # @return [EM::Mongo::RequestResponse]
     def collection_names
       response = RequestResponse.new
-      name_resp = collections_info.to_a
+      name_resp = collections_info.defer_as_a
       name_resp.callback do |docs|
         names = docs.collect{ |doc| doc['name'] || '' }
         names = names.delete_if {|name| name.index(self.name).nil? || name.index('$')}
@@ -200,7 +200,7 @@ module EM::Mongo
     def index_information(collection_name)
       response = RequestResponse.new
       sel  = {:ns => full_collection_name(collection_name)}
-      idx_resp = Cursor.new(self.collection(SYSTEM_INDEX_COLLECTION), :selector => sel).to_a
+      idx_resp = Cursor.new(self.collection(SYSTEM_INDEX_COLLECTION), :selector => sel).defer_as_a
       idx_resp.callback do |indexes|
         info = indexes.inject({}) do |info, index|
           info[index['name']] = index

--- a/lib/em-mongo/prev.rb
+++ b/lib/em-mongo/prev.rb
@@ -6,7 +6,7 @@ module EM
       def find(selector={}, opts={}, &blk)
         raise "find requires a block" if not block_given?
 
-        new_find(selector, opts).to_a.callback do |docs|
+        new_find(selector, opts).defer_as_a.callback do |docs|
           blk.call(docs)
         end
       end
@@ -38,7 +38,7 @@ module EM
 
       def find(collection_name, skip, limit, order, query, fields, &blk)
         db_name, col_name = db_and_col_name(collection_name)
-        db(db_name).collection(col_name).find(query, :skip=>skip,:limit=>limit,:order=>order,:fields=>fields).to_a.callback do |docs|
+        db(db_name).collection(col_name).find(query, :skip=>skip,:limit=>limit,:order=>order,:fields=>fields).defer_as_a.callback do |docs|
           yield docs if block_given?
         end
       end

--- a/spec/integration/collection_spec.rb
+++ b/spec/integration/collection_spec.rb
@@ -32,7 +32,7 @@ describe EMMongo::Collection do
       @conn, @coll = connection_and_collection
 
       @coll.insert("hello" => 'world')
-      @coll.find({"hello" => "world"},{}).to_a.callback do |res|
+      @coll.find({"hello" => "world"},{}).defer_as_a.callback do |res|
         res.size.should >= 1
         res[0]["hello"].should == "world"
         done
@@ -54,7 +54,7 @@ describe EMMongo::Collection do
       @conn, @coll = connection_and_collection
 
       @coll.insert('hello' => 'world')
-      @coll.find({:hello => "world"},{}).to_a.callback do |res|
+      @coll.find({:hello => "world"},{}).defer_as_a.callback do |res|
         res.size.should >= 1
         res[0]["hello"].should == "world"
         done
@@ -65,7 +65,7 @@ describe EMMongo::Collection do
       @conn, @coll = connection_and_collection
 
       id = @coll.insert('hello' => 'world')
-      @coll.find({:_id => id},{}).to_a.callback do |res|
+      @coll.find({:_id => id},{}).defer_as_a.callback do |res|
         res.size.should >= 1
         res[0]['hello'].should == "world"
         done
@@ -77,7 +77,7 @@ describe EMMongo::Collection do
 
       @coll.insert('one' => 'one')
       @coll.insert('two' => 'two')
-      @coll.find.to_a.callback do |res|
+      @coll.find.defer_as_a.callback do |res|
         res.size.should >= 2
         done
       end
@@ -90,14 +90,14 @@ describe EMMongo::Collection do
       @coll.insert(:name => 'three', :position => 2)
       @coll.insert(:name => 'two', :position => 1)
 
-      @coll.find({}, {:order => 'position'}).to_a.callback do |res|
+      @coll.find({}, {:order => 'position'}).defer_as_a.callback do |res|
         res[0]["name"].should == 'one'
         res[1]["name"].should == 'two'
         res[2]["name"].should == 'three'
         done
       end
 
-      @coll.find({}, {:order => [:position, :desc]}).to_a.callback do |res|
+      @coll.find({}, {:order => [:position, :desc]}).defer_as_a.callback do |res|
         res[0]["name"].should == 'three'
         res[1]["name"].should == 'two'
         res[2]["name"].should == 'one'
@@ -141,7 +141,7 @@ describe EMMongo::Collection do
         @coll.insert({'num' => num, 'word' => word})
       end
 
-      @coll.find({'num' => {'$in' => [1,3,5]}}).to_a.callback do |res|
+      @coll.find({'num' => {'$in' => [1,3,5]}}).defer_as_a.callback do |res|
         res.size.should == 3
         res.map{|r| r['num'] }.sort.should == [1,3,5]
         done
@@ -155,7 +155,7 @@ describe EMMongo::Collection do
         @coll.insert('num' => num, 'word' => word)
       end
 
-      @coll.find({'num' => {'$gt' => 3}}).to_a.callback do |res|
+      @coll.find({'num' => {'$gt' => 3}}).defer_as_a.callback do |res|
         res.size.should == 6
         res.map{|r| r['num'] }.sort.should == [4,5,6,7,8,9]
         done
@@ -202,7 +202,7 @@ describe EMMongo::Collection do
 
       t = Time.now.utc.freeze
       @coll.insert('date' => t)
-      @coll.find.to_a.callback do |res|
+      @coll.find.defer_as_a.callback do |res|
         res[0]['date'].to_s.should == t.to_s
         done
       end
@@ -222,7 +222,7 @@ describe EMMongo::Collection do
         'regex' => /abc$/ix
       }
       retobj = @coll.insert(obj)
-      @coll.find({:_id => obj[:_id]}).to_a.callback do |ret|
+      @coll.find({:_id => obj[:_id]}).defer_as_a.callback do |ret|
         ret.size.should == 1
         ret[0].each_key do |key|
           next if key == '_id'
@@ -262,7 +262,7 @@ describe EMMongo::Collection do
 
       id = @coll.insert('hello' => 'world')
       @coll.update({'hello' => 'world'}, {'hello' => 'newworld'})
-      @coll.find({:_id => id},{}).to_a.callback do |res|
+      @coll.find({:_id => id},{}).defer_as_a.callback do |res|
         res[0]['hello'].should == 'newworld'
         done
       end
@@ -273,7 +273,7 @@ describe EMMongo::Collection do
 
       id = @coll.insert('hello' => 'world')
       @coll.update({'hello' => 'world'}, {'$inc' => {'count' => 1}})
-      @coll.find({:_id => id},{}).to_a.callback do |res|
+      @coll.find({:_id => id},{}).defer_as_a.callback do |res|
         res.first['hello'].should == 'world'
         res.first['count'].should == 1
         done
@@ -301,7 +301,7 @@ describe EMMongo::Collection do
     it "should insert a record when no id is present" do
       @conn, @coll = connection_and_collection
       id = @coll.save("x" => 1)
-      @coll.find("x" => 1).to_a.callback do |result|
+      @coll.find("x" => 1).defer_as_a.callback do |result|
         result[0]["_id"].should == id
         done
       end
@@ -313,7 +313,7 @@ describe EMMongo::Collection do
       id = @coll.save(doc)
       doc["x"] = 2
       @coll.save(doc).should be_true
-      @coll.find().to_a.callback do |result|
+      @coll.find().defer_as_a.callback do |result|
         result.count.should == 1
         result[0]["x"].should == 2
         done
@@ -342,7 +342,7 @@ describe EMMongo::Collection do
 
       id = @coll.insert('hello' => 'world')
       @coll.remove(:_id => id)
-      @coll.find({'hello' => "world"}).to_a.callback do |res|
+      @coll.find({'hello' => "world"}).defer_as_a.callback do |res|
         res.size.should == 0
         done
       end
@@ -354,7 +354,7 @@ describe EMMongo::Collection do
       @coll.insert('one' => 'one')
       @coll.insert('two' => 'two')
       @coll.remove
-      @coll.find.to_a.callback do |res|
+      @coll.find.defer_as_a.callback do |res|
         res.size.should == 0
         done
       end

--- a/spec/integration/cursor_spec.rb
+++ b/spec/integration/cursor_spec.rb
@@ -34,7 +34,7 @@ describe EMMongo::Cursor do
       @coll.save(all[-1])
     end
 
-    cursor.limit(5).skip(3).sort("x",1).to_a.callback do |results|
+    cursor.limit(5).skip(3).sort("x",1).defer_as_a.callback do |results|
       all.slice(3...8).each_with_index do |item,idx|
         results[idx]["x"].should == item["x"]
       end
@@ -49,7 +49,7 @@ describe EMMongo::Cursor do
     1501.times do |i|
       @coll.insert(i.to_s => i.to_s)
     end
-    cursor.limit(1500).to_a.callback do |docs|
+    cursor.limit(1500).defer_as_a.callback do |docs|
       docs.length.should == 1500
       done
     end
@@ -80,12 +80,12 @@ describe EMMongo::Cursor do
     100.times do |i|
       @coll.save("x" => 1)
     end
-    cursor.to_a.callback do |r1|
+    cursor.defer_as_a.callback do |r1|
       r1.length.should == 100
-      cursor.to_a.callback do |r2|
+      cursor.defer_as_a.callback do |r2|
         r2.length.should == 0
         cursor.rewind!
-        cursor.to_a.callback do |r3|
+        cursor.defer_as_a.callback do |r3|
           r3.length.should == 100
           done
         end
@@ -101,7 +101,7 @@ describe EMMongo::Cursor do
       1000.times do |i|
         @coll.save("x" => 1)
       end
-      cursor.to_a.callback do |results|
+      cursor.defer_as_a.callback do |results|
         results.length.should == 1000
         done
       end
@@ -290,14 +290,14 @@ describe EMMongo::Cursor do
       end
     end
 
-    describe "to_a" do
+    describe "defer_as_a" do
       it "should return an array of all documents in a query" do
         @conn, @coll = connection_and_collection
         5.times do |i|
           @coll.insert("x" => i)
         end
         cursor = EM::Mongo::Cursor.new(@coll).sort("x",1)
-        cursor.to_a.callback do |docs|
+        cursor.defer_as_a.callback do |docs|
           docs.length.should == 5
           5.times do |i|
             docs[i]["x"].should == i


### PR DESCRIPTION
This branch replaces all uses of to_a in the Cursor class with defer_as_a. This should confuse people less. We will support to_a returning a Deferrable through an alias at least until 0.5.0.
