### PR TITLE
Allow passing options to db#create_collection

### DIFF
--- a/lib/em-mongo/database.rb
+++ b/lib/em-mongo/database.rb
@@ -114,7 +114,7 @@ module EM::Mongo
     #   already exists or collection creation fails on the server.
     #
     # @return [EM::Mongo::RequestResponse] Calls back with the new collection
-    def create_collection(name)
+    def create_collection(name, opts = {})
       response = RequestResponse.new
       names_resp = collection_names
       names_resp.callback do |names|
@@ -125,7 +125,7 @@ module EM::Mongo
         # Create a new collection.
         oh = BSON::OrderedHash.new
         oh[:create] = name
-        cmd_resp = command(oh)
+        cmd_resp = command(oh.merge(opts || {}))
         cmd_resp.callback do |doc|
           if EM::Mongo::Support.ok?(doc)
             response.succeed EM::Mongo::Collection.new(@db_name, name, @em_connection)

--- a/spec/integration/database_spec.rb
+++ b/spec/integration/database_spec.rb
@@ -37,8 +37,6 @@ describe EMMongo::Database do
   it "should create a collection with options" do
     @conn = EM::Mongo::Connection.new
     @db = @conn.db
-    # collection a from the previous test is still available so we need to
-    # create a new collection
     @db.create_collection('capped', {:capped => true, :max => 10}).callback do |col|
       @db.command({:collstats => 'capped'}).callback do |doc|
         doc['capped'].should == 1

--- a/spec/integration/database_spec.rb
+++ b/spec/integration/database_spec.rb
@@ -34,6 +34,20 @@ describe EMMongo::Database do
     end
   end
 
+  it "should create a collection with options" do
+    @conn = EM::Mongo::Connection.new
+    @db = @conn.db
+    # collection a from the previous test is still available so we need to
+    # create a new collection
+    @db.create_collection('capped', {:capped => true, :max => 10}).callback do |col|
+      @db.command({:collstats => 'capped'}).callback do |doc|
+        doc['capped'].should == 1
+        doc['max'].should == 10
+        done
+      end
+    end
+  end
+
   it "should drop a collection" do
     @conn = EM::Mongo::Connection.new
     @db = @conn.db


### PR DESCRIPTION
As discussed in #34, this allows adding a options hash to create_collection.

The documentation from the mongo ruby driver is now correct as we can set capped, size and max.

I haven't used :size in the test because I couldn't see a way that could be tested easily.

Let me know if this patch needs more work as I'd be happy to add to it.
