### PR TITLE
added MongoDB 2.4 2d indexes

### DIFF
--- a/lib/em-mongo/connection.rb
+++ b/lib/em-mongo/connection.rb
@@ -23,6 +23,8 @@ module EM::Mongo
 
   ASCENDING  =  1
   DESCENDING = -1
+  FLAT2D     = '2d'
+  SPHERE2D   = '2dsphere'
   GEO2D      = '2d'
 
   DEFAULT_MAX_BSON_SIZE = 4 * 1024 * 1024

--- a/spec/integration/collection_spec.rb
+++ b/spec/integration/collection_spec.rb
@@ -642,12 +642,22 @@ describe EMMongo::Collection do
       end
     end
 
-    it "should create a geospatial index" do
-      @conn, @geo = connection_and_collection('geo')
+    it "should create a flat 2d index" do
+      @conn, @geo = connection_and_collection('2d')
       @geo.save({'loc' => [-100, 100]})
-      @geo.create_index([['loc', EM::Mongo::GEO2D]])
+      @geo.create_index([['loc', EM::Mongo::FLAT2D]])
       @geo.index_information.callback do |info|
         info['loc_2d'].should_not be_nil
+        done
+      end
+    end
+
+    it "should create a sphere 2d index" do
+      @conn, @geo = connection_and_collection('2dsphere')
+      @geo.save({'loc' => [-100, 100]})
+      @geo.create_index([['loc', EM::Mongo::SPHERE2D]])
+      @geo.index_information.callback do |info|
+        info['loc_2dsphere'].should_not be_nil
         done
       end
     end


### PR DESCRIPTION
```
# Create a new index.
#
# @param [String, Array] spec
#   should be either a single field name or an array of
#   [field name, direction] pairs. Directions should be specified
#   as EM::Mongo::ASCENDING, EM::Mongo::DESCENDING, EM::Mongo::FLAT2D, EM::Mongo::SPHERE2D
#
#   Note that MongoDB 2.2 used 2d flat indexes and called them geo, MongoDB 2.4 has 2d and 2dsphere indexes
#   EM::Mongo::GEO2D is kept for backward compatiblity and is creating a flat 2d index
```
