### PR TITLE
Ensure that EM::Mongo::Cursor#next_document correctly handles errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+- UNRELEASED
+
+ * Correctly propagate errors in EM::Mongo::Cursor#next_document
+
+
 - 0.6.0
 
  * add SCRAM-SHA-1 authentication mechanism

--- a/lib/em-mongo/cursor.rb
+++ b/lib/em-mongo/cursor.rb
@@ -86,9 +86,11 @@ module EM::Mongo
     def next_document
       response = RequestResponse.new
       if @cache.length == 0
-        refresh.callback do
+        ref_resp = refresh
+        ref_resp.callback do
           check_and_transform_document(@cache.shift, response)
         end
+        ref_resp.errback { |err| response.fail err }
       else
         check_and_transform_document(@cache.shift, response)
       end


### PR DESCRIPTION
Disconnected :disconnected failures during #refresh have not been propagated by #next_document leading to a stuck eventloop as there is no way for a consumer to detect this - the deferrable just sits their without ever being resolved